### PR TITLE
Update version constraint to allow Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Bumped the version constraint to allow installation on Laravel 9. Double checked code against the Laravel 9 upgrade guide and didn't note any breaking changes. Tested functionality in Laravel 9 and all appears okay.

This is non-breaking as is, but Laravel v9 has a minimum PHP version requirement of 8.0.2. Will do a separate pull request to bump the minimum PHP version. See #3.