### PR TITLE
Align minimum PHP version with Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0.2",
         "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Following up #2, this PR will bump the minimum PHP version to align with Laravel 9's minimum version. Laravel 8 also supports PHP 8. https://laravel.com/docs/9.x/upgrade#updating-dependencies